### PR TITLE
Added a test when apiVersion is 0

### DIFF
--- a/external/vulkancts/modules/vulkan/api/vktApiDeviceInitializationTests.cpp
+++ b/external/vulkancts/modules/vulkan/api/vktApiDeviceInitializationTests.cpp
@@ -150,6 +150,23 @@ tcu::TestStatus createInstanceTest (Context& context)
 
 		appInfos.push_back(appInfo);
 	}
+
+	// test when apiVersion is 0
+	{
+		const VkApplicationInfo appInfo =
+		{
+			VK_STRUCTURE_TYPE_APPLICATION_INFO,		// VkStructureType				sType;
+			DE_NULL,								// const void*					pNext;
+			"appName",								// const char*					pAppName;
+			0u,										// deUint32						appVersion;
+			"engineName",							// const char*					pEngineName;
+			0u,										// deUint32						engineVersion;
+			0u,										// deUint32						apiVersion;
+		};
+
+		appInfos.push_back(appInfo);
+	}
+
 	// run the tests!
 	for (size_t appInfoNdx = 0; appInfoNdx < appInfos.size(); ++appInfoNdx)
 	{


### PR DESCRIPTION
The spec states that:
>If apiVersion is 0 the implementation **must** ignore it [...]

I added a test for that case.

It might seem a little silly, but currently the Vulkan [loader](https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers) form Khronos segfaults at [loader.h](https://github.com/KhronosGroup/Vulkan-LoaderAndValidationLayers/blob/1affe90f0ec7f9bccb6841a56a2a5b66861efe6a/loader/loader.h#L362) if you do set it to zero.
