### PR TITLE
Fix ssbo array descriptors

### DIFF
--- a/external/vulkancts/modules/vulkan/ssbo/vktSSBOLayoutCase.cpp
+++ b/external/vulkancts/modules/vulkan/ssbo/vktSSBOLayoutCase.cpp
@@ -1923,10 +1923,10 @@ tcu::TestStatus SSBOLayoutCaseInstance::iterate (void)
 
 				m_uniformBuffers.push_back(VkBufferSp(new vk::Unique<vk::VkBuffer>(buffer)));
 				m_uniformAllocs.push_back(AllocationSp(alloc.release()));
-
-				setUpdateBuilder.writeSingle(*descriptorSet, vk::DescriptorSetUpdateBuilder::Location::binding(blockNdx + 1),
-											vk::VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, &descriptors[blockNdx]);
 			}
+
+			setUpdateBuilder.writeArray(*descriptorSet, vk::DescriptorSetUpdateBuilder::Location::binding(1),
+										vk::VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, numBlocks, &descriptors[0]);
 		}
 		else
 		{
@@ -1960,10 +1960,10 @@ tcu::TestStatus SSBOLayoutCaseInstance::iterate (void)
 				const deUint32						offset		= blockLocations[blockNdx].offset;
 
 				descriptors[blockNdx] = makeDescriptorBufferInfo(*buffer, offset, bufferSize);
-
-				setUpdateBuilder.writeSingle(*descriptorSet, vk::DescriptorSetUpdateBuilder::Location::binding(blockNdx + 1),
-										vk::VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, &descriptors[blockNdx]);
 			}
+
+			setUpdateBuilder.writeArray(*descriptorSet, vk::DescriptorSetUpdateBuilder::Location::binding(1),
+										vk::VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, numBlocks, &descriptors[0]);
 
 			m_uniformBuffers.push_back(VkBufferSp(new vk::Unique<vk::VkBuffer>(buffer)));
 			m_uniformAllocs.push_back(AllocationSp(alloc.release()));

--- a/external/vulkancts/modules/vulkan/ssbo/vktSSBOLayoutCase.cpp
+++ b/external/vulkancts/modules/vulkan/ssbo/vktSSBOLayoutCase.cpp
@@ -1863,11 +1863,23 @@ tcu::TestStatus SSBOLayoutCaseInstance::iterate (void)
 	setLayoutBuilder
 		.addSingleBinding(vk::VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, vk::VK_SHADER_STAGE_COMPUTE_BIT);
 
-	const int numBlocks	= (int)m_refLayout.blocks.size();
-	for (int blockNdx = 0; blockNdx < numBlocks; blockNdx++)
+	int numBlocks = 0;
+	const int numBindings = m_interface.getNumBlocks();
+	for (int bindingNdx = 0; bindingNdx < numBindings; bindingNdx++)
 	{
-		setLayoutBuilder
-			.addSingleBinding(vk::VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, vk::VK_SHADER_STAGE_COMPUTE_BIT);
+		const BufferBlock& block = m_interface.getBlock(bindingNdx);
+		if (block.isArray())
+		{
+			setLayoutBuilder
+				.addArrayBinding(vk::VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, block.getArraySize(), vk::VK_SHADER_STAGE_COMPUTE_BIT);
+			numBlocks += block.getArraySize();
+		}
+		else
+		{
+			setLayoutBuilder
+				.addSingleBinding(vk::VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, vk::VK_SHADER_STAGE_COMPUTE_BIT);
+			numBlocks += 1;
+		}
 	}
 
 	poolBuilder


### PR DESCRIPTION
Previously, the SSBO tests would declare arrays of blocks in the shader such as
```
layout(std140, binding = 0) buffer AcBlock { highp uint ac_numPassed; };

layout(std140, binding = 1) buffer Block
{
	highp vec3 var;
} block[3];
```
and then try and pair that shader with a descriptor set layout that contained 4 separate descriptors each with `descriptorCount == 1`.  This seems to violate the spec which says that arrays in shaders map to things with `descriptorCount > 1`.