### PR TITLE
Increase minimum VkBufferCopy::size value

### DIFF
--- a/external/vulkancts/modules/vulkan/api/vktApiCopiesAndBlittingTests.cpp
+++ b/external/vulkancts/modules/vulkan/api/vktApiCopiesAndBlittingTests.cpp
@@ -1717,8 +1717,8 @@ tcu::TestCaseGroup* createCopiesAndBlittingTests (tcu::TestContext& testCtx)
 		params.src.buffer.size = size;
 		params.dst.buffer.size = size * (size + 1);
 
-		// Copy region with size 0..size
-		for (unsigned int i = 0; i <= size; i++)
+		// Copy region with size 1..size
+		for (unsigned int i = 1; i <= size; i++)
 		{
 			const VkBufferCopy bufferCopy = {
 				0,		// VkDeviceSize	srcOffset;


### PR DESCRIPTION
According to the Valid Usage section in 18.2. Copying Data Between
Buffers,

  The copySize member of a given element of pRegions must be greater
  than 0