### PR TITLE
Don't overlap VkImageCopy source regions

### DIFF
--- a/external/vulkancts/modules/vulkan/api/vktApiCopiesAndBlittingTests.cpp
+++ b/external/vulkancts/modules/vulkan/api/vktApiCopiesAndBlittingTests.cpp
@@ -1598,7 +1598,7 @@ tcu::TestCaseGroup* createCopiesAndBlittingTests (tcu::TestContext& testCtx)
 			const VkImageCopy testCopy =
 			{
 				sourceLayer,			// VkImageSubresourceLayers	srcSubresource;
-				{0, 0, 0},				// VkOffset3D				srcOffset;
+				{i*16, 240-i*16, 0},	// VkOffset3D				srcOffset;
 				sourceLayer,			// VkImageSubresourceLayers	dstSubresource;
 				{i*16, 240-i*16, 0},	// VkOffset3D				dstOffset;
 				{16, 16, 1},			// VkExtent3D				extent;


### PR DESCRIPTION
According to the Valid Usage section in 18.3. Copying Data Between
Images,

 The union of all source regions, and the union of all destination
 regions, specified by the elements of pRegions, must not overlap in
 memory